### PR TITLE
Midi controls

### DIFF
--- a/app/src/main/java/com/manichord/synthesizer/android/ui/PianoActivity2.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/ui/PianoActivity2.java
@@ -59,7 +59,14 @@ import com.manichord.synthesizer.core.midi.MidiListener;
  * be refactored to make it cleaner.
  */
 public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceChangeListener {
+  private static final int VALUE_ENCODER  = 64;
+  private static final int RESONANCE_DIAL  = 71;
+  private static final int PITCH_DIAL  = 80;
+  private static final int EDIT_DIAL  = 82;
+
   private int currentChannel = 0;
+  private int currentDial;
+
   private Intent requestFileIntent;
   private ParcelFileDescriptor inputPFD;
 
@@ -295,12 +302,31 @@ public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceC
       public void onController(final int channel, final int cc, final int value) {
         runOnUiThread(new Runnable() {
           public void run() {
-            if (cc == 1) {
+            if (cc == PITCH_DIAL) {
               cutoffKnob_.setValue(value * (1.0 / 127));
-            } else if (cc == 2) {
+              synthMidi.onController(0, 1, value);
+            } else if (cc == RESONANCE_DIAL) {
               resonanceKnob_.setValue(value * (1.0 / 127));
-            } else if (cc == 3) {
+              synthMidi.onController(0, 2, value);
+            } else if (cc == EDIT_DIAL) {
               overdriveKnob_.setValue(value * (1.0 / 127));
+              synthMidi.onController(0, 3, value);
+            } else if (cc == 98) {
+              currentDial = value;
+            } else if (cc == 97) {
+              switch (currentDial) {
+                case VALUE_ENCODER:
+                  int currentPos =  presetSpinner_.getSelectedItemPosition();
+                  presetSpinner_.setSelection(currentPos-1);
+                  break;
+              }
+            } else if (cc == 96) {
+              switch (currentDial) {
+                case VALUE_ENCODER:
+                  int currentPos =  presetSpinner_.getSelectedItemPosition();
+                  presetSpinner_.setSelection(currentPos+1);
+                  break;
+              }
             }
           }
         });

--- a/app/src/main/java/com/manichord/synthesizer/android/ui/PianoActivity2.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/ui/PianoActivity2.java
@@ -59,6 +59,7 @@ import com.manichord.synthesizer.core.midi.MidiListener;
  * be refactored to make it cleaner.
  */
 public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceChangeListener {
+  private int currentChannel = 0;
   private Intent requestFileIntent;
   private ParcelFileDescriptor inputPFD;
 
@@ -157,6 +158,7 @@ public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceC
     prefs.registerOnSharedPreferenceChangeListener(this);
     onSharedPreferenceChanged(prefs, "keyboard_type");
     onSharedPreferenceChanged(prefs, "vel_sens");
+    onSharedPreferenceChanged(prefs, "midi_channel");
   }
 
   @Override
@@ -175,6 +177,14 @@ public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceC
       float velSens = prefs.getFloat("vel_sens", 0.5f);
       float velAvg = prefs.getFloat("vel_avg", 64);
       keyboard_.setVelocitySensitivity(velSens, velAvg);
+    } else if (key.equals("midi_channel")) {
+      currentChannel = Integer.parseInt(prefs.getString(key, "0"));
+      if (synthesizerService_ != null) {
+        synthesizerService_.setCurrentChannel(currentChannel);
+      } else {
+        Log.d("PianoActivity2", "cannot set current channel no Synth service");
+      }
+      Log.d("PianoActivity2", "set current channel:" + currentChannel);
     }
   }
 
@@ -266,6 +276,7 @@ public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceC
     // Connect controller changes to knob views
     synthesizerService_.setMidiListener(new MidiAdapter() {
       public void onNoteOn(final int channel, final int note, final int velocity) {
+        Log.d("MAKS","NoteON:"+channel+"-"+note+":"+velocity);
         runOnUiThread(new Runnable() {
           public void run() {
             keyboard_.onNote(note, velocity);

--- a/app/src/main/java/com/manichord/synthesizer/android/ui/SettingsActivity.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/ui/SettingsActivity.java
@@ -5,6 +5,7 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
+import android.util.Log;
 
 import com.manichord.synthesizer.R;
 
@@ -22,7 +23,18 @@ public class SettingsActivity extends PreferenceActivity {
         return true;
       }
     });
+    ListPreference midiChannelPref = (ListPreference)findPreference("midi_channel");
+    updateListSummary(midiChannelPref, midiChannelPref.getValue());
+    Log.d("SettingsActivity", "mid channel:"+midiChannelPref.getValue());
+    midiChannelPref.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+      public boolean onPreferenceChange(Preference pref, Object newVal) {
+        updateListSummary(pref, newVal.toString());
+        return true;
+      }
+    });
   }
+
+
 
   private void updateListSummary(Preference pref, String newVal) {
     ListPreference lp = (ListPreference)pref;

--- a/app/src/main/java/com/manichord/synthesizer/android/usb/UsbMidiDevice.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/usb/UsbMidiDevice.java
@@ -32,7 +32,7 @@ import com.manichord.synthesizer.core.midi.MidiListener;
 
 @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
 public class UsbMidiDevice {
-  private final MidiListener mReceiver;
+  private MidiListener mReceiver;
   private final UsbDeviceConnection mDeviceConnection;
   private final UsbEndpoint mEndpoint;
 
@@ -67,6 +67,10 @@ public class UsbMidiDevice {
     synchronized (mWaiterThread) {
       mWaiterThread.mStop = true;
     }
+  }
+
+  public void replaceReceiver(MidiListener receiver) {
+    mReceiver = receiver;
   }
 
   // A helper function for clients that might want to query whether a

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,4 +105,28 @@
   <string name="pref_velSens_summary">Sensitivity of MIDI velocity to pressure</string>
   <string name="pref_velSens_default">0.5</string>
 
+  <string name="pref_midi_channel">Midi Channel</string>
+  <string name="pref_midi_channel_summary">MIDI Channel to listen on</string>
+  <string name="pref_midi_channel_default">0</string>
+  <string-array name="pref_midi_channel_entries">
+    <item>0</item>
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item>5</item>
+    <item>6</item>
+    <item>7</item>
+  </string-array>
+  <string-array name="pref_midi_channel_values">
+    <item>0</item>
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item>5</item>
+    <item>6</item>
+    <item>7</item>
+  </string-array>
+
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,4 +18,11 @@
 		android:summary="@string/pref_velSens_summary"
 		android:widgetLayout="@layout/knobpreflayout_vs"
 		android:defaultValue="@string/pref_velSens_default" />
+
+	<ListPreference
+		android:key="midi_channel"
+		android:title="@string/pref_midi_channel"
+		android:entries="@array/pref_midi_channel_entries"
+		android:entryValues="@array/pref_midi_channel_values"
+		android:defaultValue="@string/pref_midi_channel_default" />
 </PreferenceScreen>


### PR DESCRIPTION
Add setting to only listen on specific Midi channel for notes commands.
Also add midi mapping for instrument selection, cutoff dial, resonance dial, overdrive dial. For now these are just hardcoded to the CC's used by Hacktribe firmware running on a Electribe 2:  
```
VALUE_ENCODER  = 64
RESONANCE_DIAL  = 71
PITCH_DIAL  = 80
EDIT_DIAL  = 82
```