### PR TITLE
"Touch drag scroll" feature of the on-screen piano keyboard

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,9 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/droid-synth.iml" filepath="$PROJECT_DIR$/.idea/modules/droid-synth.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/droid-synth.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/droid-synth.app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/droid-synth.app.androidTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/droid-synth.app.androidTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/droid-synth.app.main.iml" filepath="$PROJECT_DIR$/.idea/modules/app/droid-synth.app.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/droid-synth.app.unitTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/droid-synth.app.unitTest.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/java/com/manichord/synthesizer/android/ui/PianoActivity2.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/ui/PianoActivity2.java
@@ -166,6 +166,7 @@ public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceC
     onSharedPreferenceChanged(prefs, "keyboard_type");
     onSharedPreferenceChanged(prefs, "vel_sens");
     onSharedPreferenceChanged(prefs, "midi_channel");
+    onSharedPreferenceChanged(prefs, "touch_drag_action");
   }
 
   @Override
@@ -192,6 +193,9 @@ public class PianoActivity2 extends SynthActivity implements OnSharedPreferenceC
         Log.d("PianoActivity2", "cannot set current channel no Synth service");
       }
       Log.d("PianoActivity2", "set current channel:" + currentChannel);
+    } else if (key.equals("touch_drag_action")) {
+      String touchDragAction = prefs.getString(key, "TDA_PlayNotes");
+      keyboard_.setTouchDragAction(KeyboardView.TouchDragAction.toTouchDragAction(touchDragAction));
     }
   }
 

--- a/app/src/main/java/com/manichord/synthesizer/android/ui/SettingsActivity.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/ui/SettingsActivity.java
@@ -32,6 +32,15 @@ public class SettingsActivity extends PreferenceActivity {
         return true;
       }
     });
+    ListPreference touchDragActionPref = (ListPreference)findPreference("touch_drag_action");
+    updateListSummary(touchDragActionPref, touchDragActionPref.getValue());
+    Log.d("SettingsActivity", "touch drag action:"+touchDragActionPref.getValue());
+    touchDragActionPref.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+      public boolean onPreferenceChange(Preference pref, Object newVal) {
+        updateListSummary(pref, newVal.toString());
+        return true;
+      }
+    });
   }
 
 

--- a/app/src/main/java/com/manichord/synthesizer/android/widgets/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/widgets/keyboard/KeyboardView.java
@@ -1,4 +1,5 @@
 /*
+ *
  * Copyright 2013 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,16 +27,33 @@ import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import android.util.Log;
+import java.lang.Math;
 
 import com.manichord.synthesizer.core.midi.MidiListener;
 
 public class KeyboardView extends View {
+
+  public enum TouchDragAction {
+    TDA_PlayNotes, TDA_ScrollKeyboard;
+
+    public static TouchDragAction toTouchDragAction(String TouchDragActionString) {
+      try {
+        return valueOf(TouchDragActionString);
+      } catch (Exception ex) {
+        return TDA_PlayNotes;
+      }
+    }
+  }
+
   public KeyboardView(Context context, AttributeSet attrs) {
     super(context, attrs);
     nKeys_ = 96;
     firstKey_ = 12;
     noteStatus_ = new byte[128];
     noteForFinger_ = new int[FINGERS];
+    touchCurrentX = new float[FINGERS];
+
     for (int i = 0; i < FINGERS; i++) {
       noteForFinger_[i] = -1;
     }
@@ -53,12 +71,19 @@ public class KeyboardView extends View {
     setKeyboardSpec(KeyboardSpec.make2Row());
     velSens_ = 0.5f;
     velAvg_ = 64;
+
+    touchDragAction_ = TouchDragAction.TDA_PlayNotes;
   }
 
   public void setKeyboardSpec(KeyboardSpec keyboardSpec) {
     keyboardSpec_ = keyboardSpec;
     keyboardScale_ = zoom_ / keyboardSpec_.repeatWidth * keyboardSpec_.keys.length / nKeys_;
     invalidate();
+  }
+
+  public void setTouchDragAction(TouchDragAction action)
+  {
+    touchDragAction_ = action;
   }
 
   public void setMidiListener(MidiListener listener) {
@@ -217,13 +242,24 @@ public class KeyboardView extends View {
 
   private boolean onTouchDown(int id, float x, float y, float pressure) {
     int note = hitTest(x, y);
+
     if (note >= 0 && noteStatus_[note] == 0) {
       int velocity = computeVelocity(pressure);
+
       noteForFinger_[id] = note;
+
       noteStatus_[note] = (byte)velocity;
       if (midiListener_ != null) {
         midiListener_.onNoteOn(0, note, velocity);
       }
+
+      if (touchDragAction_ == TouchDragAction.TDA_ScrollKeyboard)
+      {
+        touchCurrentX[id] = x;
+        if (notesPressed() == 1)
+          touchTrackingOffset = offset_;
+      }
+
       return true;
     }
     return false;
@@ -232,49 +268,97 @@ public class KeyboardView extends View {
   private boolean onTouchUp(int id, float x, float y, float pressure) {
     int note = noteForFinger_[id];
     if (note >= 0) {
+
       int velocity = noteStatus_[note];
       if (midiListener_ != null) {
         midiListener_.onNoteOff(0, note, velocity);
       }
       noteForFinger_[id] = -1;
       noteStatus_[note] = 0;
+
       return true;
     }
     return false;
   }
 
-  private boolean onTouchMove(int id, float x, float y, float pressure) {
-    int oldNote = noteForFinger_[id];
-    int newNote = hitTest(x, y);
-    if (newNote != -1 && newNote != oldNote && noteStatus_[newNote] == 0) {
-      // keep consistent velocity; new is likely to be too high
-      if (oldNote >= 0) {
-        int velocity = noteStatus_[oldNote];
-        if (midiListener_ != null) {
-          midiListener_.onNoteOff(0, oldNote, velocity);
-          midiListener_.onNoteOn(0, newNote, velocity);
+  private int notesPressed()
+  {
+    int res = 0;
+    for (int i = 0; i < FINGERS; i++) {
+      if (noteForFinger_[i] != -1)
+        res++;
+    }
+    return res;
+  }
+
+  private boolean handleScrollTouch(int id, float x)
+  {
+    if (touchDragAction_ == TouchDragAction.TDA_ScrollKeyboard)
+    {
+      if (noteForFinger_[id] != -1)
+      {
+        /*
+          The effective scroll offset is the current touch devided by the number of current active touches
+          This correspondes to the following cases:
+          - A single touch: should scroll exactly the same amount as the touch moved, no perceived mismatch between expectations and reality
+          - Multi-touch: either the player moves the fingers more or less synchronously or some of them moves more or less comparing to the others
+            The latter might introduce the sense that the scrolling moves too much or too little because of the mathematics described.
+        */
+        touchTrackingOffset = touchTrackingOffset + (x - touchCurrentX[id]) / notesPressed();
+
+        touchCurrentX[id] = x;
+
+        if (Math.abs(touchTrackingOffset - offset_) >= 1)
+        {
+          setScrollZoom(touchTrackingOffset, zoom_);
         }
-        noteForFinger_[id] = newNote;
-        noteStatus_[oldNote] = 0;
-        noteStatus_[newNote] = (byte)velocity;
-      } else {
-        // moving onto active note from dead zone
-        int velocity = 64;
-        if (midiListener_ != null) {
-          midiListener_.onNoteOn(0, newNote, velocity);
-        }
-        noteForFinger_[id] = newNote;
-        noteStatus_[newNote] = (byte)velocity;
       }
       return true;
+    } else
+      return false;
+  }
+
+  private boolean onTouchMove(int id, float x, float y, float pressure) {
+
+    if (handleScrollTouch(id, x)) {
+      return false;
+    } else {
+      int oldNote = noteForFinger_[id];
+      int newNote = hitTest(x, y);
+      if (newNote != -1 && newNote != oldNote && noteStatus_[newNote] == 0) {
+        // keep consistent velocity; new is likely to be too high
+        if (oldNote >= 0) {
+          int velocity = noteStatus_[oldNote];
+          if (midiListener_ != null) {
+            midiListener_.onNoteOff(0, oldNote, velocity);
+            midiListener_.onNoteOn(0, newNote, velocity);
+          }
+          noteForFinger_[id] = newNote;
+          noteStatus_[oldNote] = 0;
+          noteStatus_[newNote] = (byte)velocity;
+        } else {
+          // moving onto active note from dead zone
+          int velocity = 64;
+          if (midiListener_ != null) {
+            midiListener_.onNoteOn(0, newNote, velocity);
+          }
+          noteForFinger_[id] = newNote;
+          noteStatus_[newNote] = (byte)velocity;
+        }
+        return true;
+      }
+
+      return false;
     }
-  return false;
   }
 
   private static String noteString(int note) {
     int octave = note / 12 - 1;
     return NOTE_NAMES[note % 12] + Integer.toString(octave);
   }
+
+
+  private static final String TAG = "KEYBWIDGET";
 
   private float velSens_;
   private float velAvg_;
@@ -286,6 +370,10 @@ public class KeyboardView extends View {
   private float strokeWidth_;
   private float textSize_;
   private float keyboardScale_;
+
+  private float[] touchCurrentX;  // Array containing all current x positions of the note touches
+  private float touchTrackingOffset; // Tracking offset keeps the accurate offset x position and passes it to the scroll when the threashold of 1 is reached
+  private TouchDragAction touchDragAction_;  // The current behavior of the touch-drag action, either the classic way (playing new notes while touch is moving ot scrolling the keyboard)
 
   private float offset_;
   private float zoom_;

--- a/app/src/main/java/com/manichord/synthesizer/android/widgets/keyboard/KeyboardView.java
+++ b/app/src/main/java/com/manichord/synthesizer/android/widgets/keyboard/KeyboardView.java
@@ -281,43 +281,6 @@ public class KeyboardView extends View {
     return false;
   }
 
-  private int notesPressed()
-  {
-    int res = 0;
-    for (int i = 0; i < FINGERS; i++) {
-      if (noteForFinger_[i] != -1)
-        res++;
-    }
-    return res;
-  }
-
-  private boolean handleScrollTouch(int id, float x)
-  {
-    if (touchDragAction_ == TouchDragAction.TDA_ScrollKeyboard)
-    {
-      if (noteForFinger_[id] != -1)
-      {
-        /*
-          The effective scroll offset is the current touch devided by the number of current active touches
-          This correspondes to the following cases:
-          - A single touch: should scroll exactly the same amount as the touch moved, no perceived mismatch between expectations and reality
-          - Multi-touch: either the player moves the fingers more or less synchronously or some of them moves more or less comparing to the others
-            The latter might introduce the sense that the scrolling moves too much or too little because of the mathematics described.
-        */
-        touchTrackingOffset = touchTrackingOffset + (x - touchCurrentX[id]) / notesPressed();
-
-        touchCurrentX[id] = x;
-
-        if (Math.abs(touchTrackingOffset - offset_) >= 1)
-        {
-          setScrollZoom(touchTrackingOffset, zoom_);
-        }
-      }
-      return true;
-    } else
-      return false;
-  }
-
   private boolean onTouchMove(int id, float x, float y, float pressure) {
 
     if (handleScrollTouch(id, x)) {
@@ -355,6 +318,43 @@ public class KeyboardView extends View {
   private static String noteString(int note) {
     int octave = note / 12 - 1;
     return NOTE_NAMES[note % 12] + Integer.toString(octave);
+  }
+
+  private int notesPressed()
+  {
+    int res = 0;
+    for (int i = 0; i < FINGERS; i++) {
+      if (noteForFinger_[i] != -1)
+        res++;
+    }
+    return res;
+  }
+
+  private boolean handleScrollTouch(int id, float x)
+  {
+    if (touchDragAction_ == TouchDragAction.TDA_ScrollKeyboard)
+    {
+      if (noteForFinger_[id] != -1)
+      {
+        /*
+          The effective scroll offset is the current touch devided by the number of current active touches
+          This correspondes to the following cases:
+          - A single touch: should scroll exactly the same amount as the touch moved, no perceived mismatch between expectations and reality
+          - Multi-touch: either the player moves the fingers more or less synchronously or some of them moves more or less comparing to the others
+            The latter might introduce the sense that the scrolling moves too much or too little because of the mathematics described.
+        */
+        touchTrackingOffset = touchTrackingOffset + (x - touchCurrentX[id]) / notesPressed();
+
+        touchCurrentX[id] = x;
+
+        if (Math.abs(touchTrackingOffset - offset_) >= 1)
+        {
+          setScrollZoom(touchTrackingOffset, zoom_);
+        }
+      }
+      return true;
+    } else
+      return false;
   }
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,12 +89,23 @@
       <item>2 Row (Piano)</item>
       <item>3 Row</item>
       <item>3 Row Chromatic</item>
-      </string-array>
+  </string-array>
   <string-array name="pref_keyboardType_values">
       <item>2row</item>
       <item>3row</item>
       <item>3chrome</item>
-      </string-array>
+  </string-array>
+
+  <string-array name="pref_touchDragAction_entries">
+    <item>Play notes</item>
+    <item>Scroll keyboard</item>
+  </string-array>
+  <string-array name="pref_touchDragAction_values">
+    <item>TDA_PlayNotes</item>
+    <item>TDA_ScrollKeyboard</item>
+  </string-array>
+
+
   <string name="pref_keyboardType_default">2row</string>
 
   <string name="pref_velAvg">Velocity average value</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,4 +25,12 @@
 		android:entries="@array/pref_midi_channel_entries"
 		android:entryValues="@array/pref_midi_channel_values"
 		android:defaultValue="@string/pref_midi_channel_default" />
+
+	<ListPreference
+		android:key="touch_drag_action"
+		android:title="Touch Drag Action"
+		android:entries="@array/pref_touchDragAction_entries"
+		android:entryValues="@array/pref_touchDragAction_values"
+		android:defaultValue="TDA_PlayNotes" />
+
 </PreferenceScreen>


### PR DESCRIPTION
The feature allows scrolling the on-screen piano keyboard "windows" when one or more touches are still active and the user drags them to the side. This allows more flexible performance technique so one can reach more keys that fits in the current view while keeping the playing uninterrupted. 

The feature is active when the new setting `Touch Drag Action` is set to `Scroll keyboard` value. The default value is `Play Notes` that corresponds to how the app behaves without it so any new user uninterested in new feature won't notice anything new or meet an unexpected regression.  

The feature should work either with a single touch (solo melody) or with multi-touch (accords). Sometimes the border between them is blurred because formally a short period of keeping a previous key pressed and a new one introduced works as a multi-touch mode. Anyway, with multi-touch it's possible that the scrolling moves too far or too close comparing to the expectations. This might occur when the fingers are not always move synchronously, but from my perspective this is something that is possible to adapt to.   

A note for reviewing: the diff a github could not recognize that there's a small change in the implementation of `onTouchMove` method body that just introduced  `handleScrollTouch` call so there are just a couple of lines added despite a huge fragment shown here. 